### PR TITLE
chore(tooling): enable vulnerability alerts in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -136,6 +136,10 @@
     },
     {
       "description": "High Severity Security updates - immediate",
+      "matchDatasources": ["go", "npm", "osv"],
+      "vulnerabilityAlerts": {
+        "enabled": true
+      },
       "groupName": "high security updates",
       "schedule": ["at any time"],
       "automerge": false,


### PR DESCRIPTION
This change configures Renovate to automatically check for and report known security vulnerabilities in our Go, npm, and OSV dependencies.

Refs: #1 